### PR TITLE
add external connections option

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ on:
   
 jobs:
   ci:
-    name: Vet, lint and test
+    name: Vet, Lint, Test and Vulnerability Check
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
@@ -36,14 +36,12 @@ jobs:
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
         golangci-lint run --out-format=github-actions
 
-    - name: Integration Test
-      run: make test_integration
-
-  govulncheck:
-    runs-on: ubuntu-latest
-    name: Run govulncheck
-    steps:
-    - id: govulncheck
+    - name: Vulnerability Check
       uses: golang/govulncheck-action@v1
       with:
         go-package: ./...
+        go-version-input: ">=1.21.0"
+        check-latest: true
+
+    - name: Integration Test
+      run: make test_integration

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,10 @@ version: "3.4"
 services:
   rabbitmq:
       container_name: rabbitmq
-      image: 'rabbitmq:3.12.2-alpine'
+      image: 'rabbitmq:3.11.9-management'
       ports:
         - "5672:5672"
+        - "15672:15672"
       healthcheck:
         test: rabbitmq-diagnostics -q ping
         interval: 5s

--- a/eventbus.go
+++ b/eventbus.go
@@ -86,6 +86,7 @@ func NewEventBus(addr, appID, clientID, exchange, topic string, options ...Optio
 		ctx:                ctx,
 		cancel:             cancel,
 		eventCodec:         &json.EventCodec{},
+		maxRetries:         InfiniteRetries,
 		maxRecoveryRetries: InfiniteRetries,
 		tracer:             tracygo.New(),
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/Clarilab/clarimq v1.1.0
 	github.com/Clarilab/eh-tracygo v1.0.0
+	github.com/Clarilab/tracygo/v2 v2.1.0
 	github.com/google/uuid v1.4.0
 	github.com/looplab/eventhorizon v0.16.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Clarilab/eh-rabbitmq
 go 1.21
 
 require (
-	github.com/Clarilab/clarimq v0.3.1
+	github.com/Clarilab/clarimq v1.1.0
 	github.com/Clarilab/eh-tracygo v1.0.0
 	github.com/google/uuid v1.4.0
 	github.com/looplab/eventhorizon v0.16.0
@@ -12,6 +12,6 @@ require (
 require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/rabbitmq/amqp091-go v1.8.1 // indirect
+	github.com/rabbitmq/amqp091-go v1.9.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Clarilab/clarimq v1.1.0 h1:2/gk7QSMXq/DBZLmjNw+TXtWtPiAnShzfTcb5OHpch
 github.com/Clarilab/clarimq v1.1.0/go.mod h1:9WQEAIGXZdhTdhLP7fc/Pe+h+xQ6ZPI3QM5UhUFrqR8=
 github.com/Clarilab/eh-tracygo v1.0.0 h1:2KlaQfPO5ajqBinHK4Hu3vXauTG2q0W9jJ7Aim5pQFw=
 github.com/Clarilab/eh-tracygo v1.0.0/go.mod h1:bC1/XWv6byi0+YzkvuoioeV8vPruyK0jHkFo5gN5+Qc=
+github.com/Clarilab/tracygo/v2 v2.1.0 h1:5QU3NTTboXD9PK0RCvSe7hBnO/vafkX05S2IYe3m44s=
+github.com/Clarilab/tracygo/v2 v2.1.0/go.mod h1:DTUarfWtuAsbaLsXnzlQDS5nkTzXcna7ZvLIqriw5Vk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Clarilab/clarimq v0.3.1 h1:qMb0I7zDXCGUyhJrjb+RuJI8iXQ8mhTz8Eqw4jZzFm8=
-github.com/Clarilab/clarimq v0.3.1/go.mod h1:9WQEAIGXZdhTdhLP7fc/Pe+h+xQ6ZPI3QM5UhUFrqR8=
+github.com/Clarilab/clarimq v1.1.0 h1:2/gk7QSMXq/DBZLmjNw+TXtWtPiAnShzfTcb5OHpchw=
+github.com/Clarilab/clarimq v1.1.0/go.mod h1:9WQEAIGXZdhTdhLP7fc/Pe+h+xQ6ZPI3QM5UhUFrqR8=
 github.com/Clarilab/eh-tracygo v1.0.0 h1:2KlaQfPO5ajqBinHK4Hu3vXauTG2q0W9jJ7Aim5pQFw=
 github.com/Clarilab/eh-tracygo v1.0.0/go.mod h1:bC1/XWv6byi0+YzkvuoioeV8vPruyK0jHkFo5gN5+Qc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -20,8 +20,8 @@ github.com/looplab/eventhorizon v0.16.0/go.mod h1:ym7NXMZtXypXMQgEavLerP3LfESP+W
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rabbitmq/amqp091-go v1.8.1 h1:RejT1SBUim5doqcL6s7iN6SBmsQqyTgXb1xMlH0h1hA=
-github.com/rabbitmq/amqp091-go v1.8.1/go.mod h1:+jPrT9iY2eLjRaMSRHUhc3z14E/l85kv/f+6luSD3pc=
+github.com/rabbitmq/amqp091-go v1.9.0 h1:qrQtyzB4H8BQgEuJwhmVQqVHB9O4+MNDJCCAcpc3Aoo=
+github.com/rabbitmq/amqp091-go v1.9.0/go.mod h1:+jPrT9iY2eLjRaMSRHUhc3z14E/l85kv/f+6luSD3pc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=

--- a/options.go
+++ b/options.go
@@ -41,3 +41,16 @@ func WithClariMQPublishingCache(publishingCache clarimq.PublishingCache) Option 
 		b.publishingCache = publishingCache
 	}
 }
+
+// WithClariMQConnections sets the connections used for publishing and consuming events.
+func WithClariMQConnections(publishingConn *clarimq.Connection, consumeConn *clarimq.Connection) Option {
+	return func(bus *EventBus) {
+		if publishingConn != nil {
+			bus.publishConn = publishingConn
+		}
+
+		if consumeConn != nil {
+			bus.consumeConn = consumeConn
+		}
+	}
+}

--- a/options.go
+++ b/options.go
@@ -35,6 +35,15 @@ func WithRetry(maxRetries int64, delays []time.Duration) Option {
 	}
 }
 
+// WithMaxRecoveryRetry sets the max count for recovery retries.
+//
+// Default: Infinite.
+func WithMaxRecoveryRetry(maxRetries int64) Option {
+	return func(b *EventBus) {
+		b.maxRecoveryRetries = maxRetries
+	}
+}
+
 // WithClariMQPublishingCache enables caching events that failed to be published.
 func WithClariMQPublishingCache(publishingCache clarimq.PublishingCache) Option {
 	return func(b *EventBus) {

--- a/options.go
+++ b/options.go
@@ -27,6 +27,8 @@ func WithLogging(loggers []*slog.Logger) Option {
 
 // WithRetry enables event retries. If maxRetries is bigger than the number of delays provided,
 // it will use the last value until maxRetries has been reached. Use InfiniteRetries to never drop the message.
+//
+// Default maxRetries is Infinite.
 func WithRetry(maxRetries int64, delays []time.Duration) Option {
 	return func(bus *EventBus) {
 		bus.useRetry = true


### PR DESCRIPTION
- Adds option to pass RabbitMQ connections that were created beforehand.
A good use case would be to not open two new connections for every event bus instance, when multiple event busses are used inside an application
- Replaces dependency to eh-tracygo library with tracygo
- Sets the default maximum retries of the dead letter retry feature to infinite retries