### PR TITLE
feat: extend the event bus error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Clarilab/clarimq"
+	eh "github.com/looplab/eventhorizon"
 )
 
 // ErrCouldNotBeRouted is returned when a mandatory message could not be routed.
@@ -35,4 +36,11 @@ func (e *RecoveryFailedError) Error() string {
 	}
 
 	return str
+}
+
+// EventBusError is an async error containing the error returned from a handler and the event that it happened on.
+// Its a wrapper around the eventhorizon.EventBusError with extra information about the handler.
+type EventBusError struct {
+	eh.EventBusError
+	HandlerType eh.EventHandlerType
 }

--- a/handlers.go
+++ b/handlers.go
@@ -81,7 +81,7 @@ func (b *EventBus) returnHandler(rtn clarimq.Return) {
 func (b *EventBus) sendErrToErrChannel(ctx context.Context, err error, h eh.EventHandler, event eh.Event) {
 	err = fmt.Errorf("could not handle event (%s): %w", h.HandlerType(), err)
 	select {
-	case b.errCh <- &eh.EventBusError{Err: err, Ctx: ctx, Event: event}:
+	case b.errCh <- &EventBusError{eh.EventBusError{Err: err, Ctx: ctx, Event: event}, h.HandlerType()}:
 	default:
 		b.logger.logError("eventhorizon: missed error in RabbitMQ event bus", "error", err)
 	}


### PR DESCRIPTION
- extends the event bus error, that is send to the error channel to determine which handler caused the error