### PR TITLE
V2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ">=1.21.0"
+        go-version: ">=1.22.4"
 
     - name: Vet
       run: make vet
@@ -40,7 +40,7 @@ jobs:
       uses: golang/govulncheck-action@v1
       with:
         go-package: ./...
-        go-version-input: ">=1.21.0"
+        go-version-input: ">=1.22.4"
         check-latest: true
 
     - name: Integration Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,28 +2,18 @@ linters:
   enable-all: true
   disable:
     - contextcheck # Check whether the function uses a non-inherited context aka context.Background()
-    - deadcode # deprecated, replaced by unused
     - depguard # not needed, does the same as gomodguard
     - execinquery # sql linter, no need
     - exhaustruct # very annoying, checks if all struct fields are filled
-    - exhaustivestruct # deprecated, same as exhaustruct
     - ginkgolinter # not used libs
     - godot # nervig für quasi keinen impact
     - gofumpt # we don't use gofumpt
     - goheader # unused
-    - golint # deprecated, replaced by revive
-    - ifshort # deprecated
-    - interfacer # deprecated
     - lll # should be disabled in CI, as this is cosmetic only
-    - maligned # deprecated
     - nakedret # no need
-    - nosnakecase # deprecated
     - rowserrcheck # disabled because sql
-    - scopelint # deprecated
-    - structcheck # deprecated & disabled because of generics
     - sqlclosecheck # disabled because of generics
     - tagliatelle # requires ID instead of Id in jsonTags, which is annoying for our old structs
-    - varcheck  # deprecated
     - perfsprint
 linters-settings:
   cyclop:
@@ -70,7 +60,7 @@ linters-settings:
         replacement: 'a[b:]'
       - pattern: 'a[0:b]'
         replacement: 'a[:b]'
-  gomnd:
+  mnd:
     # List of function patterns to exclude from analysis.
     # Values always ignored: `time.Date`,
     # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
@@ -135,7 +125,7 @@ linters-settings:
   revive:
     enable-all-rules: true
     rules:
-      # Provided by gomnd linter
+      # Provided by mnd linter
       - name: add-constant
         disabled: true
       - name: argument-limit
@@ -232,14 +222,14 @@ issues:
         - funlen
         - goconst
         - gocyclo
-        - gomnd
+        - mnd
         - gosec
         - noctx
         - wrapcheck
 output:
   sort-results: true
 run:
-  skip-dirs:
+  exclude-dirs:
     - cmd
     - config
   # tests: false

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# eh-rabbitmq
+# eh-rabbitmq/v2
 rabbitmq event bus implementation for eventhorizon

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
   rabbitmq:
       container_name: rabbitmq
-      image: 'rabbitmq:3.11.9-management'
+      image: 'rabbitmq:3.13.3-management'
       ports:
         - "5672:5672"
         - "15672:15672"

--- a/errors.go
+++ b/errors.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Clarilab/clarimq"
+	"github.com/Clarilab/clarimq/v2"
 	eh "github.com/Clarilab/eventhorizon"
 )
 

--- a/eventbus_test.go
+++ b/eventbus_test.go
@@ -38,10 +38,6 @@ import (
 )
 
 func Test_Integration_AddHandler(t *testing.T) { //nolint:paralleltest // must not run in parallel
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
 	bus, _, err := newTestEventBus("")
 	if err != nil {
 		t.Fatal("there should be no error:", err)
@@ -53,10 +49,6 @@ func Test_Integration_AddHandler(t *testing.T) { //nolint:paralleltest // must n
 }
 
 func Test_Integration_RemoveHandler(t *testing.T) { //nolint:paralleltest // must not run in parallel
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
 	bus, _, err := newTestEventBus("app-id")
 	if err != nil {
 		t.Fatal("there should be no error:", err)
@@ -102,10 +94,6 @@ func Test_Integration_RemoveHandler(t *testing.T) { //nolint:paralleltest // mus
 }
 
 func Test_Integration_EventBus(t *testing.T) { //nolint:paralleltest // must not run in parallel
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
 	bus1, appID, err := newTestEventBus("", rabbitmq.WithHandlerConsumeAfterAdd(true))
 	if err != nil {
 		t.Fatal("there should be no error:", err)
@@ -126,10 +114,6 @@ func Test_Integration_EventBus(t *testing.T) { //nolint:paralleltest // must not
 }
 
 func Test_Integration_EventBusLoadTest(t *testing.T) { //nolint:paralleltest // must not run in parallel
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
 	bus, appID, err := newTestEventBus("", rabbitmq.WithHandlerConsumeAfterAdd(true))
 	if err != nil {
 		t.Fatal("there should be no error:", err)

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -1,0 +1,48 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+
+	eh "github.com/Clarilab/eventhorizon"
+)
+
+// EventHandler is an interface for a type that handles events.
+type EventHandler interface {
+	eh.EventHandler
+	// Event returns the event types the handler is able to handle.
+	Events() eh.MatchEvents
+	// Topic returns the topic the handler is subscribed to.
+	Topic() string
+}
+
+// SetupEventHandler sets up an Eventhandler to the event bus.
+func (b *EventBus) SetupEventHandler(ctx context.Context, eventHandler EventHandler) error {
+	const errMessage = "failed to setup event handler: %w"
+
+	if err := b.AddHandlerWithOptions(
+		ctx,
+		eventHandler.Events(),
+		eventHandler,
+		WithHandlerTopic(eventHandler.Topic()),
+	); err != nil {
+		return fmt.Errorf(errMessage, err)
+	}
+
+	return nil
+}
+
+// SetupEventHandlers sets up the given event handlers.
+func (b *EventBus) SetupEventHandlers(ctx context.Context, handlers ...EventHandler) error {
+	const errMessage = "failed to add event handlers: %w"
+
+	for i := range handlers {
+		handler := handlers[i]
+
+		if err := b.SetupEventHandler(ctx, handler); err != nil {
+			return fmt.Errorf(errMessage, err)
+		}
+	}
+
+	return nil
+}

--- a/eventhandler_test.go
+++ b/eventhandler_test.go
@@ -1,0 +1,68 @@
+package rabbitmq_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	rabbitmq "github.com/Clarilab/eh-rabbitmq/v2"
+	eh "github.com/Clarilab/eventhorizon"
+)
+
+func Test_Integration_SetupEventHandlers(t *testing.T) { //nolint:paralleltest // must not run in parallel
+	bus, _, err := newTestEventBus("")
+	if err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+
+	t.Cleanup(func() { bus.Close() })
+
+	wg1 := new(sync.WaitGroup)
+	wg2 := new(sync.WaitGroup)
+
+	handler1 := &handler1{wg1}
+	handler2 := &handler2{wg2}
+
+	ctx := context.Background()
+
+	if err = bus.SetupEventHandlers(ctx, handler1, handler2); err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+
+	wg1.Add(1)
+	wg2.Add(1)
+
+	RegisterEvents()
+
+	defer UnregisterEvents()
+
+	if err := bus.StartHandling(); err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+
+	handlers := bus.RegisteredHandlers()
+	if len(handlers) != 2 {
+		t.Fatal("there should be 2 registered handlers")
+	}
+
+	if err := bus.PublishEventWithOptions(
+		ctx,
+		eh.NewEvent(Handler1Event, new(HandlerEventData), time.Now()),
+		rabbitmq.WithPublishingTopic(handler1Topic),
+	); err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+
+	if err := bus.PublishEventWithOptions(
+		ctx,
+		eh.NewEvent(Handler2Event, new(HandlerEventData), time.Now()),
+		rabbitmq.WithPublishingTopic(handler2Topic),
+	); err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+
+	// waiting for handlers to handle events.
+	wg1.Wait()
+	wg2.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/Clarilab/eh-rabbitmq
+module github.com/Clarilab/eh-rabbitmq/v2
 
 go 1.22.4
 
 require (
-	github.com/Clarilab/clarimq v1.5.0
+	github.com/Clarilab/clarimq/v2 v2.0.0
 	github.com/Clarilab/eventhorizon v0.19.0
 	github.com/Clarilab/tracygo/v2 v2.3.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Clarilab/clarimq v1.5.0 h1:OteHRSNyMK7+YDmja5a4BZLGEpHYTwq1mfQjyZuRZ0I=
-github.com/Clarilab/clarimq v1.5.0/go.mod h1:cT3V5uZiTR7oqIqma734Mbb8QtVIu0wyu7wPoN3yWZg=
+github.com/Clarilab/clarimq/v2 v2.0.0 h1:VnKg66hNHNn5A0uvUVf7Z6GcROoymi0VMadSTtaS9Tw=
+github.com/Clarilab/clarimq/v2 v2.0.0/go.mod h1:WM5ctLnLarhFBq/gEencDMysJaFjdEos2X+l6L0flpw=
 github.com/Clarilab/eventhorizon v0.19.0 h1:GYQKAsHNo6wWuBHvZdHEK6NaWZ4QsLh52L7aKgbX4vI=
 github.com/Clarilab/eventhorizon v0.19.0/go.mod h1:25VNMNBzi14uG8B2zE9ON5VejJVBUJOm3ZtWmKROceM=
 github.com/Clarilab/tracygo/v2 v2.3.0 h1:pnkAFoI/IgaihXZjMiejbVDOhqeJvyCZNbjuaST7qDc=

--- a/handler.go
+++ b/handler.go
@@ -1,7 +1,7 @@
 package rabbitmq
 
 import (
-	"github.com/Clarilab/clarimq"
+	"github.com/Clarilab/clarimq/v2"
 )
 
 type handler struct {

--- a/handlers.go
+++ b/handlers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Clarilab/clarimq"
+	"github.com/Clarilab/clarimq/v2"
 	eh "github.com/Clarilab/eventhorizon"
 )
 

--- a/logging.go
+++ b/logging.go
@@ -3,7 +3,7 @@ package rabbitmq
 import (
 	"context"
 
-	"github.com/Clarilab/clarimq"
+	"github.com/Clarilab/clarimq/v2"
 )
 
 type logger struct {

--- a/options.go
+++ b/options.go
@@ -3,7 +3,7 @@ package rabbitmq
 import (
 	"time"
 
-	"github.com/Clarilab/clarimq"
+	"github.com/Clarilab/clarimq/v2"
 	eh "github.com/Clarilab/eventhorizon"
 )
 
@@ -70,5 +70,12 @@ func WithClariMQConnections(publishingConn *clarimq.Connection, consumeConn *cla
 func WithConsumerQuantity(concurrency int) Option {
 	return func(b *EventBus) {
 		b.consumerQuantity = concurrency
+	}
+}
+
+// WithHandlerConsumeAfterAdd allows handlers to start consuming immediately after they have been added.
+func WithHandlerConsumeAfterAdd(consumeAfterAdd bool) Option {
+	return func(b *EventBus) {
+		b.handlerConsumeAfterAdd = consumeAfterAdd
 	}
 }

--- a/setup.go
+++ b/setup.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Clarilab/clarimq"
+	"github.com/Clarilab/clarimq/v2"
 	eh "github.com/Clarilab/eventhorizon"
 )
 
@@ -139,6 +139,10 @@ func (b *EventBus) declareConsumer(ctx context.Context, matcher eh.EventMatcher,
 		clarimq.WithExchangeOptionDeclare(true),
 		clarimq.WithExchangeOptionDurable(true),
 		clarimq.WithQueueOptionDurable(true),
+	}
+
+	if b.handlerConsumeAfterAdd || b.handlersStarted {
+		optionFuncs = append(optionFuncs, clarimq.WithConsumerOptionConsumeAfterCreation(true))
 	}
 
 	if b.consumerQuantity != 0 {

--- a/testhandlers_test.go
+++ b/testhandlers_test.go
@@ -1,0 +1,94 @@
+package rabbitmq_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	eh "github.com/Clarilab/eventhorizon"
+)
+
+const (
+	handler1Topic = "handler-1-topic"
+	handler2Topic = "handler-2-topic"
+)
+
+const (
+	Handler1Event = eh.EventType("handler-1-event")
+	Handler2Event = eh.EventType("handler-2-event")
+)
+
+func RegisterEvents() {
+	eh.RegisterEventData(Handler1Event, func() eh.EventData { return new(HandlerEventData) })
+	eh.RegisterEventData(Handler2Event, func() eh.EventData { return new(HandlerEventData) })
+}
+
+func UnregisterEvents() {
+	eh.UnregisterEventData(Handler1Event)
+	eh.UnregisterEventData(Handler2Event)
+}
+
+type handler1 struct {
+	wg *sync.WaitGroup
+}
+
+func (*handler1) HandlerType() eh.EventHandlerType {
+	return eh.EventHandlerType("test-handler-1")
+}
+
+func (h *handler1) HandleEvent(_ context.Context, _ eh.Event) error {
+	h.wg.Done()
+
+	return nil
+}
+
+func (*handler1) Events() eh.MatchEvents {
+	return eh.MatchEvents{
+		Handler1Event,
+	}
+}
+
+func (*handler1) Topic() string {
+	return handler1Topic
+}
+
+type HandlerEventData struct{}
+
+type handler2 struct {
+	wg *sync.WaitGroup
+}
+
+func (*handler2) HandlerType() eh.EventHandlerType {
+	return eh.EventHandlerType("test-handler-2")
+}
+
+func (h *handler2) HandleEvent(_ context.Context, _ eh.Event) error {
+	h.wg.Done()
+
+	return nil
+}
+
+func (*handler2) Events() eh.MatchEvents {
+	return eh.MatchEvents{
+		Handler2Event,
+	}
+}
+
+func (*handler2) Topic() string {
+	return handler2Topic
+}
+
+type mockErrorEventHandler struct{}
+
+func (*mockErrorEventHandler) HandlerType() eh.EventHandlerType {
+	return eh.EventHandlerType("mock-event-handler")
+}
+
+var errTestError = errors.New("error-from-mock-event-handler")
+
+func (*mockErrorEventHandler) HandleEvent(_ context.Context, _ eh.Event) error {
+	err := fmt.Errorf("failed to handle event: %w", errTestError)
+
+	return err
+}


### PR DESCRIPTION
BREAKING CHANGE:
- the eventbus now has to be started separately after the declaration 

Why?: when used in services/applications, the main setup might has not yet fully finished initializing, but the added handlers already handle events from the eventbus, which can lead to panics, and even the app not starting at all.

Note: the eventbus can be switched back to the previous behaviour by using the
WithHandlerConsumeAfterAdd() option while declaring.

Due to the breaking change: 
- bumps up the module version to v2

Also:
- updates tests
- updates linter config
- updates actions workflow