### PR TITLE
fix: only add cID to ctx if it is filled

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -62,9 +62,13 @@ func (b *EventBus) handler(
 			ctx = NewContextWithNumRetries(ctx, retryCount)
 		}
 
+		if msg.CorrelationId != "" {
+			ctx = b.tracer.NewContextWithCorrelationID(ctx, msg.CorrelationId)
+		}
+
 		// Handle the event if it did match.
 		if err := handler.HandleEvent(
-			b.tracer.NewContextWithCorrelationID(ctx, msg.CorrelationId),
+			ctx,
 			event,
 		); err != nil {
 			b.sendErrToErrChannel(ctx, err, handler, event)


### PR DESCRIPTION
If correlationID is empty, which can happen when a message is moved to a DLX, we get a context with an empty correlationID.

